### PR TITLE
Change sourceRoot and cwd

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,9 @@
 			"request": "launch",
 			"url": "http://localhost:9877/index.html",
 			"sourceMaps": true,
-			"outDir": "wwwroot/dist"
+			"outDir": "wwwroot/dist",
+			"cwd": "wwwroot",
+			"diagnosticLogging": true
 		},
 		{
 			"name": "Attach",

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -8,6 +8,7 @@ var paths = require('../paths');
 var changed = require('gulp-changed');
 var sourcemaps = require('gulp-sourcemaps');
 var tsConfig = require('../../tsconfig.json');
+var path = require('path');
 
 gulp.task('build-sass', function () {
     gulp.src(paths.files.style)
@@ -17,13 +18,14 @@ gulp.task('build-sass', function () {
       .pipe(gulp.dest(paths.folder.style));
 });
 
+var sourceRoot = path.resolve(__dirname + '/../../wwwroot/app/');
 gulp.task('build-typescript', function () {
     return gulp.src(paths.files.typescript)
             .pipe(changed(paths.folder.output, {extension: '.js'}))            
             .pipe(filelog('compiling TypeScript'))                                 
             .pipe(sourcemaps.init())       
             .pipe(ts(tsConfig.compilerOptions))
-            .pipe(sourcemaps.write({sourceRoot: '/app'}))
+            .pipe(sourcemaps.write({sourceRoot: sourceRoot}))
             .pipe(gulp.dest(paths.folder.output));    
 });
 


### PR DESCRIPTION
Two changes-
- You need to set "cwd" to the web root - I need better docs for this!
- Since the extension reads sourcemaps off the disk, `sourceRoot` needs to be a relative path or absolute local path, so '/app' won't work right now. Changing it to an absolute path set at build time to unblock you.

With this change I can hit the breakpoint and debug.
